### PR TITLE
New feature: Usage of Trigger ID`s in automations

### DIFF
--- a/custom_components/whatsapp/trigger.py
+++ b/custom_components/whatsapp/trigger.py
@@ -6,7 +6,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import EVENT_MESSAGE_RECEIVED
 
-TRIGGER_SCHEMA = vol.Schema(
+TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): "whatsapp",
         vol.Optional("from_number"): cv.string,
@@ -56,6 +56,7 @@ async def async_attach_trigger(
             {
                 "trigger": {
                     "platform": "whatsapp",
+                    "id": config.get("id"),
                     "event": data,
                     "from_number": sender,
                     "from_group": chat_name,


### PR DESCRIPTION
changed TRIGGER_SCHEMA to use the default homeassistant TRIGGER_BASE_SCHEMA and use "id" in await_action. 
This change allows usage of trigger id`s in automations.